### PR TITLE
Fix parser issues when IRQ number lower than 100.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,33 @@
 irq-tune
 ==========
 
-Manually configure you IRQ setting to performance tune your system. This is 
-particularly useful for high bandwidth servers with 40GE NICS and SSD storage
+Manually configure you IRQ setting to performance tune your system. This is
+particularly useful for high bandwidth servers with 40GE NICS and SSD storage.
 
 
 Edit the included JSON file to map IRQs to cores. IRQ can be mapped to multiple
-cores if need be
+cores if need be.
 
 For example:
-
 ```json
 [
   { "irq": "259", "cores": [36, 37], "slot":"1", "name":"iodrive-0000:0e:00.0-0" },
   { "irq": "290", "cores": [0],  "slot":"3", "name":"mlx1-0" }
-}
+]
 ```
 
 For now only significant fields above are `irq`, `cores` and `name`.
 
 You can grep through your proc file system like this:
 
-    cat /proc/interrupts | awk  '{print $1" " $51}' | grep iodrive
-    cat /proc/interrupts | awk  '{print $1" " $51}' | grep mlx1
+```shell
+cat /proc/interrupts | awk  '{print $1" " $51}' | grep iodrive
+cat /proc/interrupts | awk  '{print $1" " $51}' | grep mlx1
+```
 
 To see how you cores are arranged on your system do this:
 
-```
+```shell
 numactl --hardware | grep cpus
 node 0 cpus: 0 4 8 12 16 20 24 28 32 36 40 44
 node 1 cpus: 1 5 9 13 17 21 25 29 33 37 41 45
@@ -39,18 +40,31 @@ Example usage
 
 Set the smp affinity for all the IRQs contained on the the json file.
 
-    ./irq-tune.py --json irq.json
+```shell
+./irq-tune.py --json irq.json
+```
 
-Set all smp affinity for all the irq names contained in the json file, **ignoring** the 
-irq numbers in the file and looking them up based on the `name` field in the json:
+Set all smp affinity for all the IRQ names contained in the json file, **ignoring** the irq numbers in the file and looking them up based on the `name` field in the json:
 
-    ./irq-tune.py --auto-irq --json irq.json
-    
+```json
+[
+  { "cores": [0], "name": "eth0-txrx-1" },  
+  { "cores": [1], "name": "eth0-txrx-2" },  
+  { "cores": [2], "name": "eth0-txrx-3" },  
+  { "cores": [3], "name": "eth0-txrx-4" },  
+  { "cores": [3], "name": "eth1-txrx-1" },  
+  { "cores": [2], "name": "eth1-txrx-2" },  
+  { "cores": [1], "name": "eth1-txrx-3" },  
+  { "cores": [0], "name": "eth1-txrx-4" }   
+]
+```
+
+```shell
+./irq-tune.py --auto-irq --json irq.json
+```
+
 Get help:
 
-    /irq-tune.py -h
-    
-
-
-    
-
+```shell
+./irq-tune.py -h
+```


### PR DESCRIPTION
When IRQ number lower than 100, line index '1' is empty. It is easy to fix on local install by change index to '2' and forgot about it. In my last case, I have 8 queues on 4x10G interface with one CPU. IRQ's start from 42 < 100 < to 103. Without this patch, these settings can not be applied.

Tested with igb (some Supermicro X9 with dual E5-2650):
```
[root@csvideo irq-tune]# /usr/bin/irq-tune -j /etc/irq-tune/irq.json -a
Set IRQ [eth0-TxRx-0]: 69 to cores: 0
mask: 00000000,00000001 procfile: /proc/irq/69/smp_affinity
Set IRQ [eth0-TxRx-1]: 70 to cores: 1
mask: 00000000,00000002 procfile: /proc/irq/70/smp_affinity
Set IRQ [eth0-TxRx-2]: 71 to cores: 2
mask: 00000000,00000004 procfile: /proc/irq/71/smp_affinity
Set IRQ [eth0-TxRx-3]: 72 to cores: 3
mask: 00000000,00000008 procfile: /proc/irq/72/smp_affinity
Set IRQ [eth0-TxRx-4]: 73 to cores: 4
mask: 00000000,00000010 procfile: /proc/irq/73/smp_affinity
Set IRQ [eth0-TxRx-5]: 74 to cores: 5
mask: 00000000,00000020 procfile: /proc/irq/74/smp_affinity
Set IRQ [eth0-TxRx-6]: 75 to cores: 6
mask: 00000000,00000040 procfile: /proc/irq/75/smp_affinity
Set IRQ [eth0-TxRx-7]: 76 to cores: 7
mask: 00000000,00000080 procfile: /proc/irq/76/smp_affinity
Set IRQ [eth1-TxRx-0]: 85 to cores: 8
mask: 00000000,00000100 procfile: /proc/irq/85/smp_affinity
Set IRQ [eth1-TxRx-1]: 86 to cores: 9
mask: 00000000,00000200 procfile: /proc/irq/86/smp_affinity
Set IRQ [eth1-TxRx-2]: 87 to cores: 10
mask: 00000000,00000400 procfile: /proc/irq/87/smp_affinity
Set IRQ [eth1-TxRx-3]: 88 to cores: 11
mask: 00000000,00000800 procfile: /proc/irq/88/smp_affinity
Set IRQ [eth1-TxRx-4]: 89 to cores: 12
mask: 00000000,00001000 procfile: /proc/irq/89/smp_affinity
Set IRQ [eth1-TxRx-5]: 90 to cores: 13
mask: 00000000,00002000 procfile: /proc/irq/90/smp_affinity
Set IRQ [eth1-TxRx-6]: 91 to cores: 14
mask: 00000000,00004000 procfile: /proc/irq/91/smp_affinity
Set IRQ [eth1-TxRx-7]: 92 to cores: 15
mask: 00000000,00008000 procfile: /proc/irq/92/smp_affinity
```

Tested with tg3 (HP Microserver Gen8):
```
Set IRQ [eth0-txrx-1]: 32 to cores: 0
mask: 00000000,00000001 procfile: /proc/irq/32/smp_affinity
Set IRQ [eth1-txrx-1]: 35 to cores: 0
mask: 00000000,00000001 procfile: /proc/irq/35/smp_affinity
Set IRQ [eth0-txrx-2]: 33 to cores: 1
mask: 00000000,00000002 procfile: /proc/irq/33/smp_affinity
Set IRQ [eth1-txrx-2]: 36 to cores: 1
mask: 00000000,00000002 procfile: /proc/irq/36/smp_affinity
Set IRQ [eth0-txrx-3]: 37 to cores: 0
mask: 00000000,00000001 procfile: /proc/irq/37/smp_affinity
Set IRQ [eth1-txrx-3]: 39 to cores: 0
mask: 00000000,00000001 procfile: /proc/irq/39/smp_affinity
Set IRQ [eth0-txrx-4]: 38 to cores: 1
mask: 00000000,00000002 procfile: /proc/irq/38/smp_affinity
Set IRQ [eth1-txrx-4]: 40 to cores: 1
mask: 00000000,00000002 procfile: /proc/irq/40/smp_affinity
```

Tested with i40e (DELL PowerEdge R730xd)
```
Set IRQ [i40e-ten0-TxRx-0]: 42 to cores: 0
mask: 00000000,00000001 procfile: /proc/irq/42/smp_affinity
Set IRQ [i40e-ten0-TxRx-1]: 43 to cores: 1
mask: 00000000,00000002 procfile: /proc/irq/43/smp_affinity
Set IRQ [i40e-ten0-TxRx-2]: 44 to cores: 2
mask: 00000000,00000004 procfile: /proc/irq/44/smp_affinity
Set IRQ [i40e-ten0-TxRx-3]: 45 to cores: 3
mask: 00000000,00000008 procfile: /proc/irq/45/smp_affinity
Set IRQ [i40e-ten0-TxRx-4]: 46 to cores: 4
mask: 00000000,00000010 procfile: /proc/irq/46/smp_affinity
Set IRQ [i40e-ten0-TxRx-5]: 47 to cores: 5
mask: 00000000,00000020 procfile: /proc/irq/47/smp_affinity
Set IRQ [i40e-ten0-TxRx-6]: 48 to cores: 6
mask: 00000000,00000040 procfile: /proc/irq/48/smp_affinity
Set IRQ [i40e-ten0-TxRx-7]: 49 to cores: 7
mask: 00000000,00000080 procfile: /proc/irq/49/smp_affinity
Set IRQ [i40e-ten1-TxRx-0]: 60 to cores: 7
mask: 00000000,00000080 procfile: /proc/irq/60/smp_affinity
Set IRQ [i40e-ten1-TxRx-1]: 61 to cores: 6
mask: 00000000,00000040 procfile: /proc/irq/61/smp_affinity
Set IRQ [i40e-ten1-TxRx-2]: 62 to cores: 5
mask: 00000000,00000020 procfile: /proc/irq/62/smp_affinity
Set IRQ [i40e-ten1-TxRx-3]: 63 to cores: 4
mask: 00000000,00000010 procfile: /proc/irq/63/smp_affinity
Set IRQ [i40e-ten1-TxRx-4]: 64 to cores: 3
mask: 00000000,00000008 procfile: /proc/irq/64/smp_affinity
Set IRQ [i40e-ten1-TxRx-5]: 65 to cores: 2
mask: 00000000,00000004 procfile: /proc/irq/65/smp_affinity
Set IRQ [i40e-ten1-TxRx-6]: 66 to cores: 1
mask: 00000000,00000002 procfile: /proc/irq/66/smp_affinity
Set IRQ [i40e-ten1-TxRx-7]: 67 to cores: 0
mask: 00000000,00000001 procfile: /proc/irq/67/smp_affinity
Set IRQ [i40e-ten2-TxRx-0]: 78 to cores: 0
mask: 00000000,00000001 procfile: /proc/irq/78/smp_affinity
Set IRQ [i40e-ten2-TxRx-1]: 79 to cores: 1
mask: 00000000,00000002 procfile: /proc/irq/79/smp_affinity
Set IRQ [i40e-ten2-TxRx-2]: 80 to cores: 2
mask: 00000000,00000004 procfile: /proc/irq/80/smp_affinity
Set IRQ [i40e-ten2-TxRx-3]: 81 to cores: 3
mask: 00000000,00000008 procfile: /proc/irq/81/smp_affinity
Set IRQ [i40e-ten2-TxRx-4]: 82 to cores: 4
mask: 00000000,00000010 procfile: /proc/irq/82/smp_affinity
Set IRQ [i40e-ten2-TxRx-5]: 83 to cores: 5
mask: 00000000,00000020 procfile: /proc/irq/83/smp_affinity
Set IRQ [i40e-ten2-TxRx-6]: 84 to cores: 6
mask: 00000000,00000040 procfile: /proc/irq/84/smp_affinity
Set IRQ [i40e-ten2-TxRx-7]: 85 to cores: 7
mask: 00000000,00000080 procfile: /proc/irq/85/smp_affinity
Set IRQ [i40e-ten3-TxRx-0]: 96 to cores: 7
mask: 00000000,00000080 procfile: /proc/irq/96/smp_affinity
Set IRQ [i40e-ten3-TxRx-1]: 97 to cores: 6
mask: 00000000,00000040 procfile: /proc/irq/97/smp_affinity
Set IRQ [i40e-ten3-TxRx-2]: 98 to cores: 5
mask: 00000000,00000020 procfile: /proc/irq/98/smp_affinity
Set IRQ [i40e-ten3-TxRx-3]: 99 to cores: 4
mask: 00000000,00000010 procfile: /proc/irq/99/smp_affinity
Set IRQ [i40e-ten3-TxRx-4]: 100 to cores: 3
mask: 00000000,00000008 procfile: /proc/irq/100/smp_affinity
Set IRQ [i40e-ten3-TxRx-5]: 101 to cores: 2
mask: 00000000,00000004 procfile: /proc/irq/101/smp_affinity
Set IRQ [i40e-ten3-TxRx-6]: 102 to cores: 1
mask: 00000000,00000002 procfile: /proc/irq/102/smp_affinity
Set IRQ [i40e-ten3-TxRx-7]: 103 to cores: 0
mask: 00000000,00000001 procfile: /proc/irq/103/smp_affinity
```

Also print output tell's irq['name'], README.md fix some mistypes.
If there is interest, I could make a patch for compatibility Python 2.7/Python 3.5 (use modern format).